### PR TITLE
Fix issues with current paho library

### DIFF
--- a/mqtt-bench.go
+++ b/mqtt-bench.go
@@ -6,7 +6,7 @@ import (
 	"crypto/x509"
 	"flag"
 	"fmt"
-	MQTT "git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.golang.git"
+	MQTT "github.com/eclipse/paho.mqtt.golang"
 	"io/ioutil"
 	"os"
 	"strconv"

--- a/mqtt-bench.go
+++ b/mqtt-bench.go
@@ -100,13 +100,13 @@ func CreateClientTlsConfig(rootCAFile string, clientCertFile string, clientKeyFi
 }
 
 // 実行する。
-func Execute(exec func(clients []*MQTT.Client, opts ExecOptions, param ...string) int, opts ExecOptions) {
+func Execute(exec func(clients []MQTT.Client, opts ExecOptions, param ...string) int, opts ExecOptions) {
 	message := CreateFixedSizeMessage(opts.MessageSize)
 
 	// 配列を初期化
 	DefaultHandlerResults = make([]*SubscribeResult, opts.ClientNum)
 
-	clients := make([]*MQTT.Client, opts.ClientNum)
+	clients := make([]MQTT.Client, opts.ClientNum)
 	hasErr := false
 	for i := 0; i < opts.ClientNum; i++ {
 		client := Connect(i, opts)
@@ -151,7 +151,7 @@ func Execute(exec func(clients []*MQTT.Client, opts ExecOptions, param ...string
 
 // 全クライアントに対して、publishの処理を行う。
 // 送信したメッセージ数を返す（原則、クライアント数分となる）。
-func PublishAllClient(clients []*MQTT.Client, opts ExecOptions, param ...string) int {
+func PublishAllClient(clients []MQTT.Client, opts ExecOptions, param ...string) int {
 	message := param[0]
 
 	wg := new(sync.WaitGroup)
@@ -187,7 +187,7 @@ func PublishAllClient(clients []*MQTT.Client, opts ExecOptions, param ...string)
 }
 
 // メッセージを送信する。
-func Publish(client *MQTT.Client, topic string, qos byte, retain bool, message string) {
+func Publish(client MQTT.Client, topic string, qos byte, retain bool, message string) {
 	token := client.Publish(topic, qos, retain, message)
 
 	if token.Wait() && token.Error() != nil {
@@ -198,7 +198,7 @@ func Publish(client *MQTT.Client, topic string, qos byte, retain bool, message s
 // 全クライアントに対して、subscribeの処理を行う。
 // 指定されたカウント数分、メッセージを受信待ちする（メッセージが取得できない場合はカウントされない）。
 // この処理では、Publishし続けながら、Subscribeの処理を行う。
-func SubscribeAllClient(clients []*MQTT.Client, opts ExecOptions, param ...string) int {
+func SubscribeAllClient(clients []MQTT.Client, opts ExecOptions, param ...string) int {
 	wg := new(sync.WaitGroup)
 
 	results := make([]*SubscribeResult, len(clients))
@@ -259,11 +259,11 @@ type SubscribeResult struct {
 }
 
 // メッセージを受信する。
-func Subscribe(client *MQTT.Client, topic string, qos byte) *SubscribeResult {
+func Subscribe(client MQTT.Client, topic string, qos byte) *SubscribeResult {
 	var result *SubscribeResult = &SubscribeResult{}
 	result.Count = 0
 
-	var handler MQTT.MessageHandler = func(client *MQTT.Client, msg MQTT.Message) {
+	var handler MQTT.MessageHandler = func(client MQTT.Client, msg MQTT.Message) {
 		result.Count++
 		if Debug {
 			fmt.Printf("Received message : topic=%s, message=%s\n", msg.Topic(), msg.Payload())
@@ -292,7 +292,7 @@ func CreateFixedSizeMessage(size int) string {
 
 // 指定されたBrokerへ接続し、そのMQTTクライアントを返す。
 // 接続に失敗した場合は nil を返す。
-func Connect(id int, execOpts ExecOptions) *MQTT.Client {
+func Connect(id int, execOpts ExecOptions) MQTT.Client {
 
 	// 複数プロセスで、ClientIDが重複すると、Broker側で問題となるため、
 	// プロセスIDを利用して、IDを割り振る。
@@ -330,7 +330,7 @@ func Connect(id int, execOpts ExecOptions) *MQTT.Client {
 		var result *SubscribeResult = &SubscribeResult{}
 		result.Count = 0
 
-		var handler MQTT.MessageHandler = func(client *MQTT.Client, msg MQTT.Message) {
+		var handler MQTT.MessageHandler = func(client MQTT.Client, msg MQTT.Message) {
 			result.Count++
 			if Debug {
 				fmt.Printf("Received at defaultHandler : topic=%s, message=%s\n", msg.Topic(), msg.Payload())
@@ -353,7 +353,7 @@ func Connect(id int, execOpts ExecOptions) *MQTT.Client {
 }
 
 // 非同期でBrokerとの接続を切断する。
-func AsyncDisconnect(clients []*MQTT.Client) {
+func AsyncDisconnect(clients []MQTT.Client) {
 	wg := new(sync.WaitGroup)
 
 	for _, client := range clients {
@@ -368,7 +368,7 @@ func AsyncDisconnect(clients []*MQTT.Client) {
 }
 
 // Brokerとの接続を切断する。
-func Disconnect(client *MQTT.Client) {
+func Disconnect(client MQTT.Client) {
 	client.Disconnect(10)
 }
 

--- a/mqtt-bench.go
+++ b/mqtt-bench.go
@@ -122,7 +122,7 @@ func Execute(exec func(clients []MQTT.Client, opts ExecOptions, param ...string)
 		for i := 0; i < len(clients); i++ {
 			client := clients[i]
 			if client != nil {
-				Disconnect(client)
+				client.Disconnect(10)
 			}
 		}
 		return
@@ -140,7 +140,7 @@ func Execute(exec func(clients []MQTT.Client, opts ExecOptions, param ...string)
 	fmt.Printf("%s End benchmark\n", time.Now())
 
 	// 切断に時間がかかるため、非同期で処理を行う。
-	AsyncDisconnect(clients)
+	DisconnectClients(clients)
 
 	// 処理結果を出力する。
 	duration := (endTime.Sub(startTime)).Nanoseconds() / int64(1000000) // nanosecond -> millisecond
@@ -352,24 +352,11 @@ func Connect(id int, execOpts ExecOptions) MQTT.Client {
 	return client
 }
 
-// 非同期でBrokerとの接続を切断する。
-func AsyncDisconnect(clients []MQTT.Client) {
-	wg := new(sync.WaitGroup)
-
+// 全てのクライエントがBrokerとの接続を切断する。
+func DisconnectClients(clients []MQTT.Client) {
 	for _, client := range clients {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			Disconnect(client)
-		}()
+		client.Disconnect(10)
 	}
-
-	wg.Wait()
-}
-
-// Brokerとの接続を切断する。
-func Disconnect(client MQTT.Client) {
-	client.Disconnect(10)
 }
 
 // ファイルの存在チェックを行う。


### PR DESCRIPTION
Attempting to run mqtt-bench with a recent version of golang and the latest paho libraries has a number of issues. I'm not sure if this is because of changes to paho or the go compiler (or both), but this branch fixes the problems so it's possible to run mqtt-bench with what's available today.